### PR TITLE
Fix groovy configured projects

### DIFF
--- a/src/main/kotlin/xyz/mishkun/lobzik/LobzikPlugin.kt
+++ b/src/main/kotlin/xyz/mishkun/lobzik/LobzikPlugin.kt
@@ -31,8 +31,8 @@ class LobzikPlugin: Plugin<Project> {
             featureModulesRegex.set(extension.featureModulesRegex)
             outputDir.set(target.layout.buildDirectory.dir("reports/lobzik/analysis"))
         }
-        target.allprojects {  subproject ->
-            if(subproject != target && subproject.file("build.gradle.kts").exists()) {
+        target.allprojects { subproject ->
+            if (subproject != target && subproject.hasBuildGradleFile()) {
                 subproject.pluginManager.withPlugin(ANDROID_APP_PLUGIN) {
                     applySubplugin(target, subproject, configuration, nodesConfiguration)
                 }
@@ -45,6 +45,9 @@ class LobzikPlugin: Plugin<Project> {
             }
         }
     }
+
+    private fun Project.hasBuildGradleFile(): Boolean =
+        file("build.gradle.kts").exists() || file("build.gradle").exists()
 
     private fun applySubplugin(
         target: Project,


### PR DESCRIPTION
Amazing idea, good job. I tried to use the plugin in our project and got
```
Execution failed for task ':lobzikReport'.
> java.lang.NullPointerException (no error message)
```
I find out this happens because plugin implies subprojects to be configured by kts files but some of our modules are still in groovy.